### PR TITLE
Adding SQL_NO_CACHE in SELECT statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Colors are also used to denote slow queries: time displayed in red instead of
 green. When a query returns no rows nor affect records, "<NONE>" is displayed
 using red in reverse video.
 
+If you want to force "SQL_NO_CACHE" in your SELECT statements you can set the use_sql_no_cache variable to 1.
+
 ### debug-blind.lua
 
 Same as debug.lua, but without shell colors.

--- a/debug-blind.lua
+++ b/debug-blind.lua
@@ -16,13 +16,27 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use_sql_no_cache = 0
+
+function nocache(query)
+    local word = string.upper(string.sub(query,1,6))
+    if ( word == "SELECT" ) then
+        query = "SELECT SQL_NO_CACHE" .. query:sub(7)
+    end
+    return query
+end
+
 transaction_counter = 0
 
 function read_query( packet )
     if packet:byte() ~= proxy.COM_QUERY then
         return
     end
-    proxy.queries:append(1, string.char(proxy.COM_QUERY) .. packet:sub(2), {resultset_is_needed = true}) 
+    local query = packet:sub(2)
+    if ( use_sql_no_cache == 1 ) then
+        query = nocache(query)
+    end    
+    proxy.queries:append(1, string.char(proxy.COM_QUERY) .. query, {resultset_is_needed = true}) 
 
     return proxy.PROXY_SEND_QUERY
 end

--- a/debug-blind.lua
+++ b/debug-blind.lua
@@ -20,7 +20,7 @@ use_sql_no_cache = 0
 
 function nocache(query)
     local word = string.upper(string.sub(query,1,6))
-    if ( word == "SELECT" ) then
+    if ( word == "SELECT" and string.find(query, "SQL_NO_CACHE") == nil ) then
         query = "SELECT SQL_NO_CACHE" .. query:sub(7)
     end
     return query

--- a/debug.lua
+++ b/debug.lua
@@ -16,13 +16,27 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use_sql_no_cache = 0
+
+function nocache(query)
+    local word = string.upper(string.sub(query,1,6))
+    if ( word == "SELECT" ) then
+        query = "SELECT SQL_NO_CACHE" .. query:sub(7)
+    end
+    return query
+end
+
 transaction_counter = 0
 
 function read_query( packet )
     if packet:byte() ~= proxy.COM_QUERY then
         return
     end
-    proxy.queries:append(1, string.char(proxy.COM_QUERY) .. packet:sub(2), {resultset_is_needed = true}) 
+    local query = packet:sub(2)
+    if ( use_sql_no_cache == 1 ) then
+        query = nocache(query)
+    end   
+    proxy.queries:append(1, string.char(proxy.COM_QUERY) .. query, {resultset_is_needed = true}) 
 
     return proxy.PROXY_SEND_QUERY
 end

--- a/debug.lua
+++ b/debug.lua
@@ -20,7 +20,7 @@ use_sql_no_cache = 0
 
 function nocache(query)
     local word = string.upper(string.sub(query,1,6))
-    if ( word == "SELECT" ) then
+    if ( word == "SELECT" and string.find(query, "SQL_NO_CACHE") == nil ) then
         query = "SELECT SQL_NO_CACHE" .. query:sub(7)
     end
     return query


### PR DESCRIPTION
Hi,

I found this interesting. Sometimes we never want to use the SQL cache (to really optimize and test our queries). With this modification we can avoid the cache without change the server configuration.

So, I share this with you, hope it can be useful ;)

Do what you want of that .

++
